### PR TITLE
added old Password

### DIFF
--- a/decrypt.sh
+++ b/decrypt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-passwords="080035080035080035 Sz080035080035080035 SzSz080035080035080035"
+passwords="080035080035080035 Sz080035080035080035 SzSz080035080035080035 ß080035080035080035"
 find . -iname '*.pdf' | while read pdf; do
   if qpdf --show-encryption "$pdf" 2>&1 | grep -q "not encrypted"; then
     continue;


### PR DESCRIPTION
[Dieses PDF](http://www.is.informatik.uni-kiel.de/thalheim/vorlesungen/Informationssysteme/Weiteres%20Material/InfSys17Abgabe1HERMloesungSonderpasswort.pdf) benutzt immer noch das Password mit dem ß.